### PR TITLE
Follow the DAP for inspectVariables response

### DIFF
--- a/src/xdebugger.cpp
+++ b/src/xdebugger.cpp
@@ -294,6 +294,7 @@ namespace xpyt
         {
             nl::json json_var = nl::json::object();
             json_var["name"] = py::str(key).cast<std::string>();
+            json_var["variablesReference"] = 0;
             try
             {
                 json_var["value"] = nl::detail::to_json_impl(variables[key]);

--- a/src/xdebugger.cpp
+++ b/src/xdebugger.cpp
@@ -289,18 +289,20 @@ namespace xpyt
         py::gil_scoped_acquire acquire;
         py::object variables = py::globals();
 
-        nl::json json_var = nl::json::object();
+        nl::json json_vars = nl::json::array();
         for (const py::handle& key : variables)
         {
-            std::string k = py::str(key).cast<std::string>();
+            nl::json json_var = nl::json::object();
+            json_var["name"] = py::str(key).cast<std::string>();
             try
             {
-                json_var[k] = nl::detail::to_json_impl(variables[key]);
+                json_var["value"] = nl::detail::to_json_impl(variables[key]);
             }
             catch(std::exception&)
             {
-                json_var[k] = nl::detail::to_json_impl(py::repr(variables[key]));
+                json_var["value"] = nl::detail::to_json_impl(py::repr(variables[key]));
             }
+            json_vars.push_back(json_var);
         }
 
         nl::json reply = {
@@ -309,7 +311,7 @@ namespace xpyt
             {"success", true},
             {"command", message["command"]},
             {"body", {
-                {"variables", json_var}
+                {"variables", json_vars}
             }}
         };
 

--- a/test/test_debugger.cpp
+++ b/test/test_debugger.cpp
@@ -565,7 +565,7 @@ bool debugger_client::test_stack_trace()
 
     m_client.send_on_shell("execute_request", make_execute_request(make_code()));
     nl::json ev = m_client.wait_for_debug_event("stopped");
-    
+
     int seq = 6;
     m_client.send_on_control("debug_request", make_stacktrace_request(seq, 1));
     ++seq;
@@ -632,8 +632,14 @@ bool debugger_client::test_inspect_variables()
     m_client.send_on_control("debug_request", make_inspect_variables_request(0));
     nl::json rep = m_client.receive_on_control();
 
-    nl::json var = rep["content"]["body"]["variables"];
-    bool res = var["i"] == 4 && var["j"] == 8 && var["k"] == 5;
+    nl::json vars = rep["content"]["body"]["variables"];
+    std::cout << vars << std::endl;
+    std::cout << vars.size() << std::endl;
+    size_t size = vars.size();
+    bool res = size >= 3;
+    res = res && vars[size-3]["name"] == "i" && vars[size-3]["value"] == 4;
+    res = res && vars[size-2]["name"] == "j" && vars[size-2]["value"] == 8;
+    res = res && vars[size-1]["name"] == "k" && vars[size-1]["value"] == 5;
     return res;
 }
 
@@ -666,7 +672,7 @@ bool debugger_client::test_next()
             nl::json json = m_client.receive_on_control();
             next(seq);
         }
-    
+
         m_client.send_on_control("debug_request", make_stacktrace_request(seq, 1));
         ++seq;
         nl::json json = m_client.receive_on_control();


### PR DESCRIPTION
Fixes #194.

Example of a `inspectVariables` response:

```json
{
  "type": "response",
  "success": true,
  "request_seq": 10,
  "command": "inspectVariables",
  "body": {
    "variables": [
      {
        "name": "__builtins__",
        "value": "<module 'builtins' (built-in)>",
        "variablesReference": 0
      },
      {
        "name": "display",
        "value": "<built-in method display of PyCapsule object at 0x7f0952358f00>",
        "variablesReference": 0
      },
      {
        "name": "i",
        "value": 4,
        "variablesReference": 0
      },
      {
        "name": "j",
        "value": 8,
        "variablesReference": 0
      },
      {
        "name": "k",
        "value": 5,
        "variablesReference": 0
      }
    ]
  }
}
```

### TODO

- [x] Return a list of `Variable` for the `inspectVariables` response
- [x] Make sure to include other required fields
- [x] Improve tests for `inspectVariables`