### PR TITLE
Add warning when building as a PyPI wheel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,13 @@ set(XPYTHON_SRC
 # xeus-python is the target for the library
 add_library(xeus-python SHARED ${XEUS_PYTHON_SRC} ${XEUS_PYTHON_HEADERS})
 
+OPTION(XEUS_ENABLE_PYPI_WARNING "Enable warning on PyPI wheels" OFF)
+
+if(XEUS_ENABLE_PYPI_WARNING)
+    message(STATUS "Enabling PyPI warning.")
+    target_compile_definitions(xeus-python PRIVATE XEUS_PYTHON_PYPI_WARNING)
+endif()
+
 # xpython is the target for the kernel executable
 add_executable(xpython ${XPYTHON_SRC})
 set_target_properties(xpython PROPERTIES ENABLE_EXPORTS 1)

--- a/docs/source/dev-build-options.rst
+++ b/docs/source/dev-build-options.rst
@@ -17,6 +17,7 @@ Build
 - ``DOWNLOAD_GTEST``: downloads ``gtest`` and builds it locally instead of using a binary installation.
 - ``GTEST_SRC_DIR``: indicates where to find the ``gtest`` sources instead of downloading them.
 - ``XEUS_PYTHONHOME_RELPATH``: indicates the relative path of the PYTHONHOME with respect to the installation prefix.
+- ``ENABLE_PYPI_WARNING``: we enable this option when building PyPI wheel to show a warning.
 
 The ``BUILD_TESTS`` and ``DOWNLOAD_GTEST`` options are disabled by default. Enabling ``DOWNLOAD_GTEST`` or
 setting ``GTEST_SRC_DIR`` enables ``BUILD_TESTS``. If the ``BUILD_TESTS`` option is enabled, the `xtest` target is made available, which builds and run the test suite.

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -277,6 +277,13 @@ namespace xpyt
               "  xeus-python: a Jupyter kernel for Python\n"
               "  Python ";
         banner.append(PY_VERSION);
+#ifdef XEUS_PYTHON_PYPI_WARNING
+        banner.append("\n"
+              "\n"
+              "WARNING: this instance of xeus-python has been installed from a PyPI wheel.\n"
+              "We recommend using a general-purpose package manager instead, such as Conda/Mamba."
+              "\n");
+#endif
         result["banner"] = banner;
         result["debugger"] = true;
 


### PR DESCRIPTION
The problem is that the banner is only visible in the console.