### PR TITLE
Add `help_links` to `kernel_info_reply`

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -291,6 +291,13 @@ namespace xpyt
         result["language_info"]["version"] = PY_VERSION;
         result["language_info"]["mimetype"] = "text/x-python";
         result["language_info"]["file_extension"] = ".py";
+
+        result["help_links"] = nl::json::array();
+        result["help_links"][0] = nl::json::object({
+            {"text", "Xeus-Python Reference"},
+            {"url", "https://xeus-python.readthedocs.io"}
+        });
+
         result["status"] = "ok";
         return result;
     }


### PR DESCRIPTION
Add `help_links` to `kernel_info_reply` so the xeus-python documentation can be displayed by the frontend:

![help-links](https://user-images.githubusercontent.com/591645/76840424-73973200-6837-11ea-8ed3-62ae2d44250c.gif)
