### PR TITLE
Fix ipython display monkey patch and improve the display module

### DIFF
--- a/src/xdisplay.cpp
+++ b/src/xdisplay.cpp
@@ -1012,6 +1012,16 @@ namespace xpyt
         }
     }
 
+    py::object pngxy(const py::object& data)
+    {
+        py::module builtins = py::module::import(XPYT_BUILTINS);
+        py::module struct_module = py::module::import("struct");
+
+        std::size_t ihdr = data.attr("index")(builtins.attr("bytes")("IHDR", "UTF8")).cast<std::size_t>();
+
+        return struct_module.attr("unpack")(">ii", data[builtins.attr("slice")(ihdr + 4, ihdr + 12)]);
+    }
+
     /******************
      * display module *
      ******************/
@@ -1185,6 +1195,8 @@ namespace xpyt
             .def("__next__", &xprogressbar::next)
             .def_property("progress", &xprogressbar::get_progress, &xprogressbar::set_progress)
             .def_property("total", &xprogressbar::get_total, &xprogressbar::set_total);
+
+        display_module.def("_pngxy", &pngxy);
 
         return display_module;
     }

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -65,8 +65,8 @@ namespace xpyt
         // Monkey patching "from ipykernel.comm import Comm"
         sys.attr("modules")["ipykernel.comm"] = get_kernel_module();
 
-        // Monkey patching "from IPython.display import display"
-        sys.attr("modules")["IPython.display"] = get_display_module();
+        // Monkey patching "import IPython.core.display"
+        sys.attr("modules")["IPython.core.display"] = get_display_module();
 
         // Monkey patching "from IPython import get_ipython"
         sys.attr("modules")["IPython.core.getipython"] = get_kernel_module();
@@ -260,11 +260,11 @@ namespace xpyt
         result["implementation_version"] = XPYT_VERSION;
 
         /* The jupyter-console banner for xeus-python is the following:
-          __  _____ _   _ ___ 
+          __  _____ _   _ ___
           \ \/ / _ \ | | / __|
            >  <  __/ |_| \__ \
           /_/\_\___|\__,_|___/
-                     
+
           xeus-python: a Jupyter lernel for Python
         */
 


### PR DESCRIPTION
This patches `IPython.core.display` instead of `IPython.display`. So that we should get `Audio`, `IFrame` etc. for free.

It also implements the missing bits of `IPython.core.display` patch.