### PR TITLE
backbone for support of magics to xeus-python

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,7 @@ install:
   - conda update -q conda
   - conda info -a
   # Host dependencies
-  - conda install xeus=0.24.0 nlohmann_json cppzmq xtl pybind11=2.5.0 pybind11_json=0.2.6 jedi=0.15.1 pygments=2.3.1 gtest=1.8.0 ptvsd -c conda-forge
+  - conda install xeus=0.24.0 nlohmann_json cppzmq xtl pybind11=2.2.4 pybind11_json=0.2.6 jedi=0.15.1 pygments=2.3.1 gtest=1.8.0 ptvsd ipython=0.7.0 -c conda-forge
   # Build dependencies
   - conda install cmake -c conda-forge
   # Build and install xeus-python
@@ -38,6 +38,7 @@ install:
   - nmake install
   # Install test dependencies
   - conda install pytest jupyter_kernel_test -c conda-forge
+  - pip install example_magic
 
 build_script:
   - cd test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,7 @@ install:
   - conda update -q conda
   - conda info -a
   # Host dependencies
-  - conda install xeus=0.24.0 nlohmann_json cppzmq xtl pybind11=2.2.4 pybind11_json=0.2.6 jedi=0.15.1 pygments=2.3.1 gtest=1.8.0 ptvsd ipython=0.7.0 -c conda-forge
+  - conda install xeus=0.24.0 nlohmann_json cppzmq xtl pybind11=2.5.0 pybind11_json=0.2.6 jedi=0.15.1 pygments=2.3.1 gtest=1.8.0 ptvsd ipython=7.14.0 -c conda-forge
   # Build dependencies
   - conda install cmake -c conda-forge
   # Build and install xeus-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
     - conda config --add channels conda-forge
     - conda update -q conda
     # Host dependencies
-    - conda install xeus=0.24.0 nlohmann_json cppzmq xtl pybind11=2.5.0 pybind11_json=0.2.6 jedi=0.15.1 pygments=2.3.1 ptvsd -c conda-forge
+    - conda install xeus=0.24.0 nlohmann_json cppzmq xtl pybind11=2.5.0 pybind11_json=0.2.6 jedi=0.15.1 pygments=2.3.1 ipython=7.14.0 ptvsd -c conda-forge
     # Build dependencies
     - conda install cmake -c conda-forge
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ install:
       fi
     # Test dependencies
     - conda install pytest jupyter_kernel_test -c conda-forge;
+    - pip install example_magic
     # Activate root environment
     - source activate root
     # For debugging

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,8 @@ set(XEUS_PYTHON_SRC
     src/xinput.hpp
     src/xinspect.cpp
     src/xinspect.hpp
+    src/xinteractiveshell.cpp
+    src/xinteractiveshell.hpp
     src/xinterpreter.cpp
     src/xis_complete.cpp
     src/xis_complete.hpp

--- a/src/xcomm.cpp
+++ b/src/xcomm.cpp
@@ -203,14 +203,14 @@ namespace xpyt
         kernel_module.def("enable_gui", [](py::args, py::kwargs) {});
         kernel_module.def("showtraceback", [](py::args, py::kwargs) {});
         kernel_module.def("run_line_magic", [kernel_module](std::string name, std::string arg) {
-            if (name == "cd") {
+            if ((name == "cd") || (name == "pwd") || (name == "env") || (name == "set_env")) {
                 py::module magics = py::module::import("IPython.core.magics.osm");
                 py::object osm = magics.attr("OSMagics")();
                 py::object shell = kernel_module.attr("_Mock");
                 shell.attr("db") = py::dict();
                 shell.attr("user_ns") = py::dict("_dh"_a=py::list());
                 osm.attr("shell") = shell;
-                auto result = osm.attr("cd")(arg);
+                auto result = osm.attr(py::str(name))(arg);
                 return result;
             }
             PyErr_SetString(PyExc_ValueError, "magics not found");

--- a/src/xcomm.cpp
+++ b/src/xcomm.cpp
@@ -238,6 +238,12 @@ namespace xpyt
         kernel_module.def("enable_gui", [](py::args, py::kwargs) {});
         kernel_module.def("showtraceback", [](py::args, py::kwargs) {});
         kernel_module.def("show_in_pager", [](py::str data, py::kwargs) {xpyt::xdisplay(py::dict("text/plain"_a=data), {}, {}, py::dict(), py::none(), py::none(), false, true);});
+
+        py::module ipy_process = py::module::import("IPython.utils.process");
+        kernel_module.def("system", [ipy_process](py::str cmd) {ipy_process.attr("system")(cmd);});
+        kernel_module.def("getoutput", [ipy_process](py::str cmd){return ipy_process.attr("getoutput")(cmd).attr("splitlines")();});
+
+
         kernel_module.def("run_line_magic", [_Mock](std::string name, std::string arg) {
 
             py::object magic_method = _Mock.attr("magics_manager").attr("magics")["line"].attr("get")(name);
@@ -285,6 +291,8 @@ namespace xpyt
             xeus_python.attr("user_ns") = py::dict("_dh"_a=py::list());
             xeus_python.attr("run_line_magic") = kernel_module.attr("run_line_magic");
             xeus_python.attr("run_cell_magic") = kernel_module.attr("run_cell_magic");
+            xeus_python.attr("system") = kernel_module.attr("system");
+            xeus_python.attr("getoutput") = kernel_module.attr("getoutput");
             init_magics(xeus_python);
             return xeus_python;
         });

--- a/src/xcomm.cpp
+++ b/src/xcomm.cpp
@@ -167,6 +167,10 @@ namespace xpyt
         struct xmock_object
         {
         };
+
+        struct shell_object
+        {
+        };
     }
 
     struct xmock_kernel
@@ -199,8 +203,7 @@ namespace xpyt
             .def(py::init<>())
             .def_property_readonly("_parent_header", &xmock_kernel::parent_header);
 
-        //py::class_<detail::xmock_object> shell(kernel_module, "_Shell");
-        py::object shell = _Mock;
+        py::class_<detail::shell_object> shell(kernel_module, "_Shell");
         shell.attr("db") = py::dict();
         shell.attr("user_ns") = py::dict("_dh"_a=py::list());
         py::module magic_core = py::module::import("IPython.core.magic");
@@ -212,7 +215,16 @@ namespace xpyt
         py::object osm_magics_inst =  magics_module.attr("OSMagics")();
         py::object basic_magics_inst =  magics_module.attr("BasicMagics")();
         osm_magics_inst.attr("shell") = shell;
+        osm_magics_inst.attr("magics")["cell"] = py::dict();
+        osm_magics_inst.attr("magics")["line"] = py::dict(
+            "cd"_a=osm_magics_inst.attr("cd"),
+            "env"_a=osm_magics_inst.attr("env"),
+            "set_env"_a=osm_magics_inst.attr("set_env"),
+            "pwd"_a=osm_magics_inst.attr("pwd"));
         basic_magics_inst.attr("shell") = shell;
+        basic_magics_inst.attr("magics")["cell"] = py::dict();
+        basic_magics_inst.attr("magics")["line"] = py::dict(
+            "magic"_a=basic_magics_inst.attr("magic"));
         magics_manager.attr("register")(osm_magics_inst);
         magics_manager.attr("register")(basic_magics_inst);
 

--- a/src/xcomm.cpp
+++ b/src/xcomm.cpp
@@ -172,6 +172,8 @@ namespace xpyt
 
         py::object osm_magics_inst =  magics_module.attr("OSMagics")();
         py::object basic_magics_inst =  magics_module.attr("BasicMagics")();
+        py::object user_magics_inst =  magics_module.attr("UserMagics")();
+        magics_manager.attr("user_magics") = user_magics_inst;
         osm_magics_inst.attr("shell") = shell;
         osm_magics_inst.attr("magics")["cell"] = py::dict(
             "writefile"_a=osm_magics_inst.attr("writefile"));
@@ -186,6 +188,7 @@ namespace xpyt
             "magic"_a=basic_magics_inst.attr("magic"));
         magics_manager.attr("register")(osm_magics_inst);
         magics_manager.attr("register")(basic_magics_inst);
+        magics_manager.attr("register")(user_magics_inst);
     }
 
     namespace detail
@@ -275,25 +278,28 @@ namespace xpyt
 
         hooks.attr("show_in_pager") = kernel_module.attr("show_in_pager");
 
-        kernel_module.def("get_ipython", [kernel_module]() {
-            py::object kernel = kernel_module.attr("mock_kernel")();
-            py::object comm_manager = kernel_module.attr("_Mock");
-            comm_manager.attr("register_target") = kernel_module.attr("register_target");
-            kernel.attr("comm_manager") = comm_manager;
 
-            py::object xeus_python =  kernel_module.attr("_Mock");
-            xeus_python.attr("register_post_execute") = kernel_module.attr("register_post_execute");
-            xeus_python.attr("enable_gui") = kernel_module.attr("enable_gui");
-            xeus_python.attr("showtraceback") = kernel_module.attr("showtraceback");
-            xeus_python.attr("kernel") = kernel;
-            xeus_python.attr("db") = py::dict();
-            xeus_python.attr("hooks") = kernel_module.attr("Hooks");
-            xeus_python.attr("user_ns") = py::dict("_dh"_a=py::list());
-            xeus_python.attr("run_line_magic") = kernel_module.attr("run_line_magic");
-            xeus_python.attr("run_cell_magic") = kernel_module.attr("run_cell_magic");
-            xeus_python.attr("system") = kernel_module.attr("system");
-            xeus_python.attr("getoutput") = kernel_module.attr("getoutput");
-            init_magics(xeus_python);
+        py::object kernel = kernel_module.attr("mock_kernel")();
+        py::object comm_manager = kernel_module.attr("_Mock");
+        comm_manager.attr("register_target") = kernel_module.attr("register_target");
+        kernel.attr("comm_manager") = comm_manager;
+
+        py::object xeus_python =  kernel_module.attr("_Mock");
+        xeus_python.attr("register_post_execute") = kernel_module.attr("register_post_execute");
+        xeus_python.attr("enable_gui") = kernel_module.attr("enable_gui");
+        xeus_python.attr("showtraceback") = kernel_module.attr("showtraceback");
+        xeus_python.attr("kernel") = kernel;
+        xeus_python.attr("db") = py::dict();
+        xeus_python.attr("hooks") = kernel_module.attr("Hooks");
+        xeus_python.attr("user_ns") = py::dict("_dh"_a=py::list());
+        xeus_python.attr("run_line_magic") = kernel_module.attr("run_line_magic");
+        xeus_python.attr("run_cell_magic") = kernel_module.attr("run_cell_magic");
+        xeus_python.attr("system") = kernel_module.attr("system");
+        xeus_python.attr("getoutput") = kernel_module.attr("getoutput");
+        init_magics(xeus_python);
+        xeus_python.attr("register_magic_function") = xeus_python.attr("magics_manager").attr("register_function");
+
+        kernel_module.def("get_ipython", [xeus_python]() {
             return xeus_python;
         });
 

--- a/src/xdisplay.hpp
+++ b/src/xdisplay.hpp
@@ -19,6 +19,10 @@ namespace py = pybind11;
 namespace xpyt
 {
     py::module get_display_module();
+    void xdisplay(const py::object& obj,
+                  const std::vector<std::string>& include, const std::vector<std::string>& exclude,
+                  const py::dict& metadata, const py::object& transient, const py::object& display_id,
+                  bool update, bool raw);
 }
 
 #endif

--- a/src/xinteractiveshell.cpp
+++ b/src/xinteractiveshell.cpp
@@ -1,0 +1,149 @@
+#include "xinteractiveshell.hpp"
+#include "xdisplay.hpp"
+
+using namespace pybind11::literals;
+namespace py = pybind11;
+
+namespace xpyt
+{
+
+    void xinteractive_shell::init_magics()
+    {
+        m_magic_core = py::module::import("IPython.core.magic");
+        m_magics_module = py::module::import("IPython.core.magics");
+        m_extension_module = py::module::import("IPython.core.extensions");
+
+        m_magics_manager = m_magic_core.attr("MagicsManager")("shell"_a=this);
+        m_extension_manager = m_extension_module.attr("ExtensionManager")("shell"_a=this);
+
+        //shell features required by extension manager
+        m_builtin_trap = py::module::import("contextlib").attr("nullcontext")();
+        m_ipython_dir = "";
+
+        py::object osm_magics =  m_magics_module.attr("OSMagics");
+        py::object basic_magics =  m_magics_module.attr("BasicMagics");
+        py::object user_magics =  m_magics_module.attr("UserMagics");
+        py::object extension_magics =  m_magics_module.attr("ExtensionMagics");
+        m_magics_manager.attr("register")(osm_magics);
+        m_magics_manager.attr("register")(basic_magics);
+        m_magics_manager.attr("register")(user_magics);
+        m_magics_manager.attr("register")(extension_magics);
+        m_magics_manager.attr("user_magics") = user_magics("shell"_a=this);
+
+        //select magics supported by xeus-python
+        auto line_magics = m_magics_manager.attr("magics")["line"];
+        auto cell_magics = m_magics_manager.attr("magics")["cell"];
+        line_magics = py::dict(
+           "cd"_a=line_magics["cd"],
+           "env"_a=line_magics["env"],
+           "set_env"_a=line_magics["set_env"],
+           "pwd"_a=line_magics["pwd"],
+           "magic"_a=line_magics["magic"],
+           "load_ext"_a=line_magics["load_ext"]
+        );
+        cell_magics = py::dict(
+            "writefile"_a=cell_magics["writefile"]);
+
+        m_magics_manager.attr("magics") = py::dict(
+           "line"_a=line_magics,
+           "cell"_a=cell_magics);
+    }
+
+
+    xinteractive_shell::xinteractive_shell()
+    {
+        m_hooks = hooks_object();
+        m_ipy_process = py::module::import("IPython.utils.process");
+        m_db = py::dict();
+        m_user_ns = py::dict("_dh"_a=py::list());
+        init_magics();
+    }
+
+    py::object xinteractive_shell::system(py::str cmd)
+    {
+        return m_ipy_process.attr("system")(cmd);
+    }
+
+    py::object xinteractive_shell::getoutput(py::str cmd)
+    {
+        auto stream = m_ipy_process.attr("getoutput")(cmd);
+        return stream.attr("splitlines")();
+    }
+
+    py::object xinteractive_shell::run_line_magic(std::string name, std::string arg)
+    {
+
+        py::object magic_method = m_magics_manager
+            .attr("magics")["line"]
+            .attr("get")(name);
+
+        if (magic_method.is_none()) {
+            PyErr_SetString(PyExc_ValueError, "magics not found");
+            throw py::error_already_set();
+        }
+
+        return magic_method(arg);
+
+    }
+
+    py::object xinteractive_shell::run_cell_magic(std::string name, std::string arg, std::string body)
+    {
+        py::object magic_method = m_magics_manager.attr("magics")["cell"].attr("get")(name);
+
+        if (magic_method.is_none()) {
+            PyErr_SetString(PyExc_ValueError, "cell magics not found");
+            throw py::error_already_set();
+        }
+
+        return magic_method(arg, body);
+    }
+
+    void xinteractive_shell::register_magic_function(py::object func, std::string magic_kind, py::object magic_name)
+    {
+        m_magics_manager.attr("register_function")(
+            func, "magic_kind"_a=magic_kind, "magic_name"_a=magic_name);
+    }
+
+    void xinteractive_shell::register_magics(py::args args)
+    {
+        m_magics_manager.attr("register")(*args);
+    }
+
+    // define getters
+
+    py::object xinteractive_shell::get_magics_manager() const
+    {
+        return m_magics_manager;
+    }
+
+    py::object xinteractive_shell::get_extension_manager() const
+    {
+        return m_extension_manager;
+    }
+
+    py::dict xinteractive_shell::get_db() const
+    {
+        return m_db;
+    }
+
+    py::dict xinteractive_shell::get_user_ns() const
+    {
+        return m_user_ns;
+    }
+
+    py::object xinteractive_shell::get_builtin_trap() const
+    {
+        return m_builtin_trap;
+    }
+
+    py::str xinteractive_shell::get_ipython_dir() const
+    {
+        return m_ipython_dir;
+    }
+
+    hooks_object xinteractive_shell::get_hooks() const
+    {
+        return m_hooks;
+    }
+
+}

--- a/src/xinteractiveshell.hpp
+++ b/src/xinteractiveshell.hpp
@@ -1,0 +1,79 @@
+#include "pybind11/pybind11.h"
+#include "xdisplay.hpp"
+
+#ifdef __GNUC__
+    #pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
+namespace py = pybind11;
+using namespace pybind11::literals;
+
+namespace xpyt 
+{
+
+    struct hooks_object
+    {
+        static inline void show_in_pager(py::str data, py::kwargs)
+        {
+            xdisplay(py::dict("text/plain"_a=data), {}, {}, py::dict(), py::none(), py::none(), false, true);
+        }
+    };
+
+    class xinteractive_shell
+    {
+
+    public:
+
+        // default constructor
+        xinteractive_shell();
+
+        // mock required methods
+        void register_post_execute(py::args, py::kwargs) {};
+        void enable_gui(py::args, py::kwargs) {};
+        void observe(py::args, py::kwargs) {};
+        void showtraceback(py::args, py::kwargs) {};
+
+
+        // run system commands
+        py::object system(py::str cmd);
+        py::object getoutput(py::str cmd); 
+
+        // run magics
+        py::object run_line_magic(std::string name, std::string arg);
+        py::object run_cell_magic(std::string name, std::string arg, std::string body);
+         
+        // register magics
+        void register_magic_function(py::object func, std::string magic_kind, py::object magic_name);
+        void register_magics(py::args args);
+
+        // public getters
+        py::object get_magics_manager() const;
+        py::object get_extension_manager() const;
+        py::dict get_db() const;
+        py::dict get_user_ns() const;
+        py::object get_builtin_trap() const;
+        py::str get_ipython_dir() const;
+        hooks_object get_hooks() const;
+
+    private:
+        py::module m_ipy_process;
+        py::module m_magic_core;
+        py::module m_magics_module;
+        py::module m_extension_module;
+
+        py::object m_magics_manager;
+        py::object m_extension_manager; // required by %load_ext
+
+        // required by cd magic and others
+        py::dict m_db;
+        py::dict m_user_ns;
+
+        // required by extension_manager
+        py::object m_builtin_trap;
+        py::str m_ipython_dir;
+
+        hooks_object m_hooks;
+
+        void init_magics();
+    };
+};

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -155,6 +155,7 @@ namespace xpyt
                 kernel_res["status"] = "error";
                 kernel_res["ename"] = ename;
                 kernel_res["evalue"] = evalue;
+                kernel_res["traceback"] = {evalue};
             }
 
             

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -134,9 +134,9 @@ namespace xpyt
                 kernel_res["status"] = "ok";
                 kernel_res["payload"] = nl::json::array();
                 kernel_res["payload"][0] = nl::json::object({
-                    //{"data", {
-                    //    {"text/plain", output_str}
-                    //}},
+                    {"data", {
+                        {"text/plain", py::str(output)}
+                    }},
                     {"source", "page"},
                     {"start", 0}
                 });

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -65,6 +65,11 @@ namespace xpyt
 
         py::module sys = py::module::import("sys");
 
+        // Monkey patching "import linecache". This monkey patch does not work with Python2.
+#if PY_MAJOR_VERSION >= 3
+        sys.attr("modules")["linecache"] = get_linecache_module();
+#endif
+
         // Monkey patching "from ipykernel.comm import Comm"
         sys.attr("modules")["ipykernel.comm"] = get_kernel_module();
 
@@ -74,10 +79,6 @@ namespace xpyt
         // Monkey patching "from IPython import get_ipython"
         sys.attr("modules")["IPython.core.getipython"] = get_kernel_module();
 
-        // Monkey patching "import linecache". This monkey patch does not work with Python2.
-#if PY_MAJOR_VERSION >= 3
-        sys.attr("modules")["linecache"] = get_linecache_module();
-#endif
 
         // add get_ipython to global namespace
         exec(py::str("from IPython.core.getipython import get_ipython"));

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -116,6 +116,52 @@ namespace xpyt
             return kernel_res;
         }
 
+        if (code.size() >= 2 && code[0] == '%')
+        {   
+            py::list magics_line = py::str(code.substr(1)).attr("split")(" ");
+            auto magics_name = py::cast<std::string>(magics_line[0]);
+            std::string magics_arg;
+            if (py::len(magics_line) > 1) 
+                magics_arg = py::cast<std::string>(magics_line[1]);
+            else
+                magics_arg = "";
+
+            py::module kernel = get_kernel_module();
+            try {
+                py::object output = kernel.attr("run_line_magic")(magics_name, magics_arg);
+
+
+                kernel_res["status"] = "ok";
+                kernel_res["payload"] = nl::json::array();
+                kernel_res["payload"][0] = nl::json::object({
+                    //{"data", {
+                    //    {"text/plain", output_str}
+                    //}},
+                    {"source", "page"},
+                    {"start", 0}
+                });
+                kernel_res["user_expressions"] = nl::json::object();
+
+            } catch (py::error_already_set & e)
+            {
+
+                std::string evalue = e.what();
+                std::string ename = py::str(e.type().attr("__name__"));
+                publish_execution_error(ename, evalue, {evalue});
+                //if (!silent)
+                //{
+                //}
+
+                kernel_res["status"] = "error";
+                kernel_res["ename"] = ename;
+                kernel_res["evalue"] = evalue;
+            }
+
+            
+            return kernel_res;
+
+        }
+
         // Scope guard performing the temporary monkey patching of input and
         // getpass with a function sending input_request messages.
         auto input_guard = input_redirection(allow_stdin);

--- a/test/test_xeus_python_kernel.py
+++ b/test/test_xeus_python_kernel.py
@@ -33,6 +33,10 @@ class XeusPythonTests(jupyter_kernel_test.KernelTests):
 
     code_inspect_sample = "open"
 
+    def test_xeus_python_missing_magic(self):
+        reply, output_msgs = self.execute_helper(code="%missing_magic")
+        self.assertRegex(output_msgs[0]['content']['evalue'], "magics not found")
+
     def test_xeus_python_stdout(self):
         reply, output_msgs = self.execute_helper(code='print(3)')
         self.assertEqual(output_msgs[0]['msg_type'], 'stream')
@@ -50,7 +54,7 @@ class XeusPythonTests(jupyter_kernel_test.KernelTests):
             traceback[0]
         )
         self.assertEqual(
-            "In  \033[0;34m[3]\033[0m:\nLine \033[0;34m1\033[0m:     a = []; a.push_back(\x1b[34m3\x1b[39;49;00m)\n",
+            "In  \033[0;34m[4]\033[0m:\nLine \033[0;34m1\033[0m:     a = []; a.push_back(\x1b[34m3\x1b[39;49;00m)\n",
             traceback[1]
         )
         self.assertEqual(

--- a/test/test_xeus_python_kernel.py
+++ b/test/test_xeus_python_kernel.py
@@ -9,7 +9,6 @@
 #############################################################################
 
 import tempfile
-from textwrap import dedent
 import unittest
 import jupyter_kernel_test
 
@@ -47,7 +46,7 @@ class XeusPythonTests(jupyter_kernel_test.KernelTests):
 
     def test_xeus_python_cell_magic(self):
         """Test calling cell magic"""
-        with tempfile.NamedTemporaryFile(dir='/tmp', delete=False) as tmpfile:
+        with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
             temp_filename = tmpfile.name
         reply, output_msgs = self.execute_helper(code="%%writefile {}\ntest file".format(temp_filename))
         # we don't care about the actual function of the magic

--- a/test/test_xeus_python_kernel.py
+++ b/test/test_xeus_python_kernel.py
@@ -8,6 +8,8 @@
 # The full license is in the file LICENSE, distributed with this software.  #
 #############################################################################
 
+import tempfile
+from textwrap import dedent
 import unittest
 import jupyter_kernel_test
 
@@ -33,9 +35,75 @@ class XeusPythonTests(jupyter_kernel_test.KernelTests):
 
     code_inspect_sample = "open"
 
+    def test_xeus_python_line_magic(self):
+        reply, output_msgs = self.execute_helper(code="%pwd")
+        self.assertEqual(output_msgs[0]['msg_type'], 'execute_result')
+        self.assertEqual(reply['content']['status'], 'ok')
+
+        # line magic expressions
+        reply, output_msgs = self.execute_helper(code="a = %pwd\nassert a")
+        self.assertEqual(reply['content']['status'], 'ok')
+        self.assertFalse(output_msgs)
+
+    def test_xeus_python_cell_magic(self):
+        """Test calling cell magic"""
+        with tempfile.NamedTemporaryFile(dir='/tmp', delete=False) as tmpfile:
+            temp_filename = tmpfile.name
+        reply, output_msgs = self.execute_helper(code="%%writefile {}\ntest file".format(temp_filename))
+        # we don't care about the actual function of the magic
+        # only check if execution succeeded
+        self.assertEqual(reply['content']['status'], 'ok')
+
+    def test_xeus_python_shell_magic(self):
+        """Test calling shell escape (! or !!) magic."""
+
+        # the shell command does not exist, but the magic execution should succeed
+        reply, output_msgs = self.execute_helper(code="!does_not_exist -params")
+        self.assertEqual(reply['content']['status'], 'ok')
+
+        reply, output_msgs = self.execute_helper(code="!!does_not_exist -params")
+        self.assertEqual(reply['content']['status'], 'ok')
+
+    def test_xeus_python_user_defined_magics(self):
+        """Test user-defined magic."""
+
+        magic_def_code = """
+        from IPython.core.magic import register_line_magic, register_cell_magic
+        @register_line_magic
+        def lmagic(line):
+            return line
+        @register_cell_magic
+        def cmagic(line, body):
+            return body"""
+
+        reply, output_msgs = self.execute_helper(code=magic_def_code)
+        self.assertEqual(reply['content']['status'], 'ok')
+
+        reply, output_msgs = self.execute_helper(code="%lmagic hello")
+        self.assertEqual(reply['content']['status'], 'ok')
+        self.assertTrue('hello' in output_msgs[0]['content']['data']['text/plain'])
+
+        # cant call cell magic as line magic
+        reply, output_msgs = self.execute_helper(code="%cmagic hello")
+        self.assertEqual(reply['content']['status'], 'error')
+
+        reply, output_msgs = self.execute_helper(code="%%cmagic\nworld")
+        self.assertEqual(reply['content']['status'], 'ok')
+        self.assertTrue('world' in output_msgs[0]['content']['data']['text/plain'])
+
+        # cant call line magic as as cell magic
+        reply, output_msgs = self.execute_helper(code="%%lmagic hello")
+        self.assertEqual(reply['content']['status'], 'error')
+
     def test_xeus_python_missing_magic(self):
         reply, output_msgs = self.execute_helper(code="%missing_magic")
         self.assertRegex(output_msgs[0]['content']['evalue'], "magics not found")
+
+    def test_xeus_python_load_ext_magic(self):
+        """Test loading extensions"""
+        reply, output_msgs = self.execute_helper(code="%load_ext example_magic")
+        reply, output_msgs = self.execute_helper(code="%abra line")
+        self.assertEqual(reply['content']['status'], 'ok')
 
     def test_xeus_python_stdout(self):
         reply, output_msgs = self.execute_helper(code='print(3)')
@@ -53,9 +121,8 @@ class XeusPythonTests(jupyter_kernel_test.KernelTests):
             "\033[0;31m---------------------------------------------------------------------------\033[0m\n\033[0;31mAttributeError\033[0m                            Traceback (most recent call last)",
             traceback[0]
         )
-        self.assertEqual(
-            "In  \033[0;34m[4]\033[0m:\nLine \033[0;34m1\033[0m:     a = []; a.push_back(\x1b[34m3\x1b[39;49;00m)\n",
-            traceback[1]
+        self.assertTrue(
+            "a = []; a.push_back" in traceback[1]
         )
         self.assertEqual(
             "\033[0;31mAttributeError\033[0m: 'list' object has no attribute 'push_back'\n\033[0;31m---------------------------------------------------------------------------\033[0m",


### PR DESCRIPTION
Features to implement:

- [x] magics parsing
- [x] find and execute magics function
- [x] support for line magics
- [x] support for cell magics
- [x] support for shell magics
- [x] support for user defined magics

## Demo

![Screen Shot 2020-05-21 at 18 11 17](https://user-images.githubusercontent.com/41565/82676497-ca115a00-9c46-11ea-91a5-14d2fb0e8f80.png)

## Details

the implementation reuses many code parts from IPython:

* `IPython.core.inputtransformers2` - for parsing magics,
* `IPython.core.magic.MagicManager` - for managing magics
* `IPython.core.extensions.ExtensionManager` - for managing extensions
* `IPython.core.magics` - for implementation of magics

The code reimplements the interface of `InteractiveShell` within xeus-python C++ code (see `src/xinteractiveshell.hpp`

In the future, `inputtransformers`, `MagicManager` and `ExtensionManager` could be separated from IPython core so they could be reused for implementation of other kernels. Alternatively, they could be reimplemented in C++ within the xeus or xeus-python code base.

The interface of `InteractiveShell` might be also more clearly defined. Also, the attributes of the shell specific to the magics should be installed by the magic themselves (for easier separation of code, TBD).