### PR TITLE
Added debugger info to metadata in kernelspec

### DIFF
--- a/share/jupyter/kernels/xpython/kernel.json.in
+++ b/share/jupyter/kernels/xpython/kernel.json.in
@@ -5,5 +5,6 @@
       "-f",
       "{connection_file}"
   ],
-  "language": "python"
+  "language": "python",
+  "metadata": { "debugger": true }
 }


### PR DESCRIPTION
This change is required for merging [this fix in the frontend](https://github.com/jupyterlab/debugger/pull/457).