### PR TITLE
Use Py_SetProgramName

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,6 +101,11 @@ int main(int argc, char* argv[])
     signal(SIGSEGV, handler);
 #endif
 
+    // Setting Program Name
+    static const std::string argv0(argv[0]);
+    static const std::wstring wargv0(argv0.cbegin(), argv0.cend());;
+    Py_SetProgramName(const_cast<wchar_t*>(wargv0.c_str()));
+
     // Setting PYTHONHOME
     xpyt::set_pythonhome();
     print_pythonhome();


### PR DESCRIPTION
Another way to do things would be to use `PySys_SetArgvEx`, but we still need to convert argv to `wchar_t`.

Another way to do things instead of converting would be to use `wmain` instead of `main`. I am not sure how standard that is.