### PR TITLE
Make initial GIL release in xinterpreter optional

### DIFF
--- a/include/xeus-python/xinterpreter.hpp
+++ b/include/xeus-python/xinterpreter.hpp
@@ -82,7 +82,15 @@ namespace xpyt
         // interpreter wants to execute Python code. This means that whenever
         // the interpreter will execute Python code it will need to create an
         // `gil_scoped_acquire` instance first.
+        //
+        // By default GIL is locked, therefore configure_impl() releases it.
+        // If an application has already released the GIL by the time the interpreter
+        // is started, m_release_gil_at_startup has to be set to false to prevent
+        // releasing it again in configure_impl().
+        //
+        bool m_release_gil_at_startup = true;
         gil_scoped_release_ptr m_release_gil = nullptr;
+
         bool m_has_ipython;
     };
 }

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -63,9 +63,13 @@ namespace xpyt
 
     void interpreter::configure_impl()
     {
-        // The GIL is not held by default by the interpreter, so every time we need to execute Python code we
-        // will need to acquire the GIL
-        m_release_gil = gil_scoped_release_ptr(new py::gil_scoped_release());
+        if (m_release_gil_at_startup)
+        {
+            // The GIL is not held by default by the interpreter, so every time we need to execute Python code we
+            // will need to acquire the GIL
+            //
+            m_release_gil = gil_scoped_release_ptr(new py::gil_scoped_release());
+        }
 
         py::gil_scoped_acquire acquire;
 


### PR DESCRIPTION
Magics support is great, thanks a lot for implementing it! These developments made `interpreter::configure_impl()` quite complex, so we wanted to use it in our custom interpreter (in 3D Slicer) instead of reimplementing it. However, we could not use `interpreter::configure_impl()` as it was, as it released the GIL at startup, which crashed our application (because the GIL was already released).

This commit adds m_release_gil_at_startup member variable. Derived classes can set to this variable false to prevent initial GIL release (see how it is used in 3D Slicer [here](https://github.com/lassoan/SlicerJupyter/commit/dc37281ed52e2581e8a3c59a92e12eeb9c059f43)). Default behavior has not been changed (GIL is released at startup by default).