### PR TITLE
Add support for extensions

### DIFF
--- a/include/xeus-python/xinterpreter.hpp
+++ b/include/xeus-python/xinterpreter.hpp
@@ -74,6 +74,7 @@ namespace xpyt
 
         void redirect_output();
         void redirect_display(bool install_hook=true);
+        void load_extensions();
 
         py::object m_displayhook;
 


### PR DESCRIPTION
This implements support for IPython extensions. They must be installed under `$PREFIX/etc/xeus-python/extensions/` and have the following JSON format:
```json
{
    "module": "module_name",
    "enabled": true
}
```