### PR TITLE
Require ipywidgets>=7.6 for JupyterLab 3 support

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,6 @@ dependencies:
   - xeus-python=0.9.5
   - jedi=0.18.0
   - notebook
-  - ipywidgets>=7.4
+  - ipywidgets>=7.6
   - jupyterlab=3
   - itkwidgets


### PR DESCRIPTION
So the widgets work out of the box on Binder with JupyterLab 3.0.