### PR TITLE
Change cmake build in README to out-of-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ conda install cmake xeus nlohmann_json cppzmq xtl pybind11 pybind11_json ipython
 Then you can compile the sources (replace `$CONDA_PREFIX` with a custom installation prefix if need be)
 
 ```bash
-cmake -D CMAKE_PREFIX_PATH=$CONDA_PREFIX -D CMAKE_INSTALL_PREFIX=$CONDA_PREFIX -D CMAKE_INSTALL_LIBDIR=lib -D PYTHON_EXECUTABLE=`which python`
+mkdir build && cd build
+cmake .. -D CMAKE_PREFIX_PATH=$CONDA_PREFIX -D CMAKE_INSTALL_PREFIX=$CONDA_PREFIX -D CMAKE_INSTALL_LIBDIR=lib -D PYTHON_EXECUTABLE=`which python`
 make && make install
 ```
 


### PR DESCRIPTION
This is kind of a dumb thing to submit a PR for, but it caught my eye. The current `cmake` instructions in the README result in an in-source build. In-source builds are considered to be bad practice, and bad advice to give beginners. I changed the instructions to instead create an out-of-source build.

There are a number of reasons to prefer out-of-source over in-source, but the big one is that the resulting `build` dir is easy to nuke and recreate, no matter how badly you screw things up.