### PR TITLE
Remove TODO for passing argv

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -156,7 +156,6 @@ class XPythonShellApp(BaseIPythonApplication, InteractiveShellApp):
         )"), scope);
 
         m_ipython_shell_app = scope["XPythonShellApp"]();
-        // TODO Pass argv to initialize
         m_ipython_shell_app.attr("initialize")();
         m_ipython_shell = m_ipython_shell_app.attr("shell");
 


### PR DESCRIPTION
We don't need to manually pass argv as it will be set to sys.argv in Traitlets (see https://github.com/ipython/traitlets/blob/11e840600ad740984034d3418142ec979b3ebfae/traitlets/config/application.py#L672).

We just need to be sure that sys.argv is correctly set, which is the case for xpython, but not for the xpython wheel.