### PR TITLE
Keep a reference to the IPython logger in the interpreter

### DIFF
--- a/include/xeus-python/xinterpreter.hpp
+++ b/include/xeus-python/xinterpreter.hpp
@@ -77,6 +77,7 @@ namespace xpyt
         py::object m_ipython_shell_app;
         py::object m_ipython_shell;
         py::object m_displayhook;
+        py::object m_logger;
 
         // The interpreter has the same scope as a `gil_scoped_release` instance
         // so that the GIL is not held by default, it will only be held when the

--- a/src/xstream.cpp
+++ b/src/xstream.cpp
@@ -8,7 +8,9 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
+#include <iostream>
 #include <string>
+#include <sstream>
 
 #include "xeus/xinterpreter.hpp"
 
@@ -70,6 +72,42 @@ namespace xpyt
         return false;
     }
 
+    /********************************
+     * xterminal_stream declaration *
+     ********************************/
+
+    class xterminal_stream
+    {
+    public:
+
+        xterminal_stream();
+        virtual ~xterminal_stream();
+
+        void write(const std::string& message);
+        void flush();
+    };
+
+    /***********************************
+     * xterminal_stream implementation *
+     ***********************************/
+
+    xterminal_stream::xterminal_stream()
+    {
+    }
+
+    xterminal_stream::~xterminal_stream()
+    {
+    }
+
+    void xterminal_stream::write(const std::string& message)
+    {
+        std::cout << message;
+    }
+
+    void xterminal_stream::flush()
+    {
+    }
+
     /*****************
      * stream module *
      *****************/
@@ -83,6 +121,11 @@ namespace xpyt
             .def("write", &xstream::write)
             .def("flush", &xstream::flush)
             .def("isatty", &xstream::isatty);
+
+        py::class_<xterminal_stream>(stream_module, "TerminalStream")
+            .def(py::init<>())
+            .def("write", &xterminal_stream::write)
+            .def("flush", &xterminal_stream::flush);
 
         return stream_module;
     }


### PR DESCRIPTION
This PR redirects all IPython logging to the terminal.

It also allows kernels inheriting from xeus-python like xeus-robot to log custom information using `m_logger`.