### PR TITLE
Implemented rich inspect variables request

### DIFF
--- a/include/xeus-python/xdebugger.hpp
+++ b/include/xeus-python/xdebugger.hpp
@@ -29,6 +29,8 @@ namespace xpyt
     {
     public:
 
+        using base_type = xeus::xdebugger_base;
+
         debugger(zmq::context_t& context,
                  const xeus::xconfiguration& config,
                  const std::string& user_name,
@@ -40,6 +42,7 @@ namespace xpyt
     private:
 
         nl::json inspect_variables_request(const nl::json& message);
+        nl::json rich_inspect_variables_request(const nl::json& message);
         nl::json attach_request(const nl::json& message);
         nl::json configuration_done_request(const nl::json& message);
 


### PR DESCRIPTION
@fcollonval the content of the debug request to send is:

```
{
    "type": "request", 
    "seq":  int, 
    "command": "richInspectVariables",
    "body": {
        "onBreakpoint", bool,
        "variableName": string,
        "variableReference", int
    }
}
```
The "onBreakpoint" field is temporary, I need to release xeus so I can get it out. For now, this only works when the debugger did not stop on a breakpoint. In this case, you can omit the `variableReference` field.