### PR TITLE
Remove custom global variables after use

### DIFF
--- a/src/xdebugger.cpp
+++ b/src/xdebugger.cpp
@@ -168,7 +168,7 @@ namespace xpyt
         if (base_type::get_stopped_threads().empty())
         {
             // The code did not hit a breakpoint, we use the interpreter 
-            // to get the rich reprensentation of the variable
+            // to get the rich representation of the variable
             std::string code = "from IPython import get_ipython;";
             code += var_repr_data + ',' + var_repr_metadata + "= get_ipython().display_formatter.format(" + var_name + ")";
             py::gil_scoped_acquire acquire;
@@ -219,6 +219,8 @@ namespace xpyt
                 body["metadata"][data_key] = repr_metadata[key];
             }
         }
+        PyDict_DelItem(variables.ptr(), py::str(var_repr_data).ptr());
+        PyDict_DelItem(variables.ptr(), py::str(var_repr_metadata).ptr());
         reply["body"] = body;
         reply["success"] = true;
         return reply;


### PR DESCRIPTION
Fixes #460. It seems that there is [no `del` method](https://github.com/pybind/pybind11/blob/af6218ff78d480c5e93237174ee6f02ec36853cc/include/pybind11/pytypes.h#L1334-L1353) for dict in `pybind11` and it needs to be directly called instead. I tested it locally with https://github.com/jupyterlab/jupyterlab/pull/10299 and by running `test_xeus_python`.

Some side notes:
- I think that CONTRIBUTING.md has outdated list of conda requirements (the README.md one is ok)
- It took me a few minutes to find out how to run tests, it would be nice to have this in CONTRIBUTION.md too

Thanks for your awesome work here :)