### PR TITLE
cmake: Support compiling with an absolute PYTHONHOME

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,8 @@ macro(xpyt_create_target target_name linkage output_name)
 
     if (XEUS_PYTHONHOME_RELPATH)
         target_compile_definitions(${target_name} PRIVATE XEUS_PYTHONHOME_RELPATH=${XEUS_PYTHONHOME_RELPATH})
+    elseif (XEUS_PYTHONHOME_ABSPATH)
+        target_compile_definitions(${target_name} PRIVATE XEUS_PYTHONHOME_ABSPATH=${XEUS_PYTHONHOME_ABSPATH})
     endif()
 endmacro()
 

--- a/docs/source/dev-build-options.rst
+++ b/docs/source/dev-build-options.rst
@@ -53,6 +53,7 @@ Other options
 
 - ``XPYT_ENABLE_PYPI_WARNING``: We enable this option when building PyPI wheel to show a warning discouraging the use of PyPI. **Disabled by default**.
 - ``XEUS_PYTHONHOME_RELPATH``: indicates the relative path of the PYTHONHOME with respect to the installation prefix of the ``xpython`` target. This variable is unset by default.
+- ``XEUS_PYTHONHOME_ABSPATH``: indicates the absolute path of the PYTHONHOME for the ``xpython`` target. This variable is unset by default.
 
-By default, ``XEUS_PYTHONHOME_RELPATH`` is unset and the PYTHONHOME is set to the installation prefix, which is the expected behavior for most cases. A situation in which we may need to specify a different value for ``XEUS_PYTHONHOME_RELPATH`` is when using a Python installation from a different prefix. This occurs for example when building the conda package for xeus-python windows, since Python is installed in the general ``PREFIX`` while xeus-python is installed in the ``LIBRARY_PREFIX``.
+By default, ``XEUS_PYTHONHOME_RELPATH`` and ``XEUS_PYTHONHOME_ABSPATH`` are unset and the PYTHONHOME is set to the installation prefix, which is the expected behavior for most cases. A situation in which we may need to specify a different value for ``XEUS_PYTHONHOME_RELPATH`` or ``XEUS_PYTHONHOME_ABSPATH`` is when using a Python installation from a different prefix. This occurs for example when building the conda package for xeus-python windows, since Python is installed in the general ``PREFIX`` while xeus-python is installed in the ``LIBRARY_PREFIX``.
 

--- a/src/xpaths.cpp
+++ b/src/xpaths.cpp
@@ -41,6 +41,8 @@ namespace xpyt
             // to specify the PYTHONHOME location as a relative path to the PREFIX.
 #if defined(XEUS_PYTHONHOME_RELPATH)
             static const std::string pythonhome = xtl::prefix_path() + XPYT_STRINGIFY(XEUS_PYTHONHOME_RELPATH);
+#elif defined(XEUS_PYTHONHOME_ABSPATH)
+            static const std::string pythonhome = XPYT_STRINGIFY(XEUS_PYTHONHOME_ABSPATH);
 #else
             static const std::string pythonhome = xtl::prefix_path();
 #endif


### PR DESCRIPTION
Useful on systems such as NixOS and Guix where Python is installed in a
totally different directory which can't refer to with a relative path.