### PR TITLE
Update post.js so that it includes missing ERRNO_CODES

### DIFF
--- a/wasm_patches/post.js
+++ b/wasm_patches/post.js
@@ -1,3 +1,5 @@
-if (!('wasmTable' in Module)) {
-    Module['wasmTable'] = wasmTable
-}
+// Emscripten doesn't make UTF8ToString or wasmTable available on Module by default...
+Module.UTF8ToString = UTF8ToString;
+Module.wasmTable = wasmTable;
+// Emscripten has a bug where it accidentally exposes an empty object as Module.ERRNO_CODES
+Module.ERRNO_CODES = ERRNO_CODES;


### PR DESCRIPTION
ERRNO_CODES is empty by default in emscripten.

This is needed for proper error handling when xeus-python will support the JupyterLite virtual file system (see https://github.com/jupyterlite/jupyterlite/pull/655)