### PR TITLE
Missing include

### DIFF
--- a/src/xdebugger.cpp
+++ b/src/xdebugger.cpp
@@ -11,6 +11,7 @@
 #include <cctype>
 #include <cstdlib>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <thread>
 


### PR DESCRIPTION
I was having
```
/xeus-python/src/xdebugger.cpp:241:18: error: 'clog' is not a member of 'std'
  241 |             std::clog << ename << " - " << evalue << std::endl;
      |                  ^~~~
/xeus-python/src/xdebugger.cpp:241:18: note: 'std::clog' is defined in header '<iostream>'; did you forget to '#include <iostream>'?
```