### PR TITLE
POC: Creation of a Comm Python package

### DIFF
--- a/include/xeus-python/xinterpreter.hpp
+++ b/include/xeus-python/xinterpreter.hpp
@@ -79,7 +79,6 @@ namespace xpyt
         py::object m_displayhook;
         py::object m_logger;
         py::object m_terminal_stream;
-        py::object m_comm_manager;
 
         // The interpreter has the same scope as a `gil_scoped_release` instance
         // so that the GIL is not held by default, it will only be held when the

--- a/include/xeus-python/xinterpreter.hpp
+++ b/include/xeus-python/xinterpreter.hpp
@@ -79,6 +79,7 @@ namespace xpyt
         py::object m_displayhook;
         py::object m_logger;
         py::object m_terminal_stream;
+        py::object m_comm_manager;
 
         // The interpreter has the same scope as a `gil_scoped_release` instance
         // so that the GIL is not held by default, it will only be held when the

--- a/src/xcomm.cpp
+++ b/src/xcomm.cpp
@@ -144,6 +144,16 @@ namespace xpyt
             .def(py::init<>())
             .def("register_target", &xcomm_manager::register_target);
 
+        comm_module.def("create_comm", [&comm_module](py::args objs, py::kwargs kw) {
+            return comm_module.attr("Comm")(*objs, **kw);
+        });
+
+        comm_module.def("get_comm_manager", [&comm_module]() {
+            static py::object comm_manager = comm_module.attr("CommManager")();
+
+            return comm_manager;
+        });
+
         return comm_module;
     }
 

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -65,6 +65,7 @@ namespace xpyt
         py::gil_scoped_acquire acquire;
 
         py::module sys = py::module::import("sys");
+        py::module comm = py::module::import("comm");
         py::module logging = py::module::import("logging");
 
         py::module display_module = get_display_module();
@@ -73,8 +74,12 @@ namespace xpyt
         py::module comm_module = get_comm_module();
         py::module kernel_module = get_kernel_module();
 
-        // Monkey patching "from ipykernel.comm import Comm"
-        sys.attr("modules")["ipykernel.comm"] = comm_module;
+        // TODO Handle old ipywidgets by monkey patching ipykernel too...
+        comm.attr("register_comm_classes")(
+            comm_module.attr("Comm"),
+            comm_module.attr("CommManager")
+        );
+        m_comm_manager = comm.attr("create_comm_manager")();
 
         instanciate_ipython_shell();
 

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -65,7 +65,6 @@ namespace xpyt
         py::gil_scoped_acquire acquire;
 
         py::module sys = py::module::import("sys");
-        py::module comm = py::module::import("comm");
         py::module logging = py::module::import("logging");
 
         py::module display_module = get_display_module();
@@ -74,12 +73,10 @@ namespace xpyt
         py::module comm_module = get_comm_module();
         py::module kernel_module = get_kernel_module();
 
-        // TODO Handle old ipywidgets by monkey patching ipykernel too...
-        comm.attr("register_comm_classes")(
-            comm_module.attr("Comm"),
-            comm_module.attr("CommManager")
-        );
-        m_comm_manager = comm.attr("create_comm_manager")();
+        // Old approach: ipykernel provides the comm
+        sys.attr("modules")["ipykernel.comm"] = comm_module;
+        // New approach: we provide our comm module
+        sys.attr("modules")["comm"] = comm_module;
 
         instanciate_ipython_shell();
 


### PR DESCRIPTION
Related discussions:
- https://github.com/jupyter-xeus/xeus-python/issues/342 
- https://github.com/jupyter-widgets/ipywidgets/issues/3514

Currently working on a Python comm package on https://github.com/martinRenou/comm for now, but it should probably be moved in the IPython org

This has the benefit of being able to:
- remove the ipykernel dependency in ipywidgets https://github.com/jupyter-widgets/ipywidgets/pull/3533
- remove the ipykernel monkey patch in xeus-python https://github.com/jupyter-xeus/xeus-python/pull/548
- remove the ipykernel package mock in jupyterlite's pyolite 
- remove the ipykernel package mock in emscripten-forge