### PR TITLE
Add the copy-to-globals flag in debug_info response

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ endif()
 # ============
 
 set(xtl_REQUIRED_VERSION 0.7.0)
-set(xeus-zmq_REQUIRED_VERSION 1.0.1)
+set(xeus-zmq_REQUIRED_VERSION 1.2.0)
 set(xeus-lite_REQUIRED_VERSION 1.0.1)
 set(pybind11_REQUIRED_VERSION 2.6.1)
 set(pybind11_json_REQUIRED_VERSION 0.2.8)
@@ -511,7 +511,7 @@ if (XPYT_BUILD_SHARED)
 endif ()
 
 if (EMSCRIPTEN)
- 
+
     install(FILES
             "$<TARGET_FILE_DIR:xpython>/xpython.js"
             "$<TARGET_FILE_DIR:xpython>/xpython.wasm"

--- a/src/xdebugger.cpp
+++ b/src/xdebugger.cpp
@@ -358,7 +358,8 @@ namespace xpyt
                                     get_tmp_prefix(),
                                     get_tmp_suffix(),
                                     true,
-                                    {"Python Exceptions"});
+                                    {"Python Exceptions"},
+                                    true);
     }
 
     std::string debugger::get_cell_temporary_file(const std::string& code) const


### PR DESCRIPTION
Should wait for https://github.com/jupyter-xeus/xeus-zmq/pull/12 to be merged and released.
Then we should update the required version to the latest https://github.com/jupyter-xeus/xeus-python/blob/5bcd30240d4e8cf20b7bcc3b59e8f2d3fab1c220/CMakeLists.txt#L91