### PR TITLE
require `pyjs >= 1.0.0`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,15 +193,14 @@ jobs:
         run: |
           micromamba activate xeus-python-wasm-build
 
-          ./$HOME/emsdk activate ${{matrix.emsdk_ver}}
-          source $CONDA_EMSDK_DIR/emsdk_env.sh
+          $HOME/emsdk activate ${{matrix.emsdk_ver}}
+          source $HOME/emsdk/emsdk_env.sh
 
           micromamba create -f environment-wasm-host.yml --platform=emscripten-32
 
           mkdir build
           pushd build
 
-          export EMPACK_PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-python-wasm-build
           export PREFIX=$MAMBA_ROOT_PREFIX/envs/xeus-python-wasm-host
           export CMAKE_PREFIX_PATH=$PREFIX
           export CMAKE_SYSTEM_PREFIX_PATH=$PREFIX
@@ -212,14 +211,8 @@ jobs:
             -DXPYT_EMSCRIPTEN_WASM_BUILD=ON \
             ..
 
-          make -j5
+          make -j5 
 
-          empack pack env --env-prefix $PREFIX --outname python_data --config $EMPACK_PREFIX/share/empack/empack_config.yaml
-
-          popd
-
-          # Patch output
-          python wasm_patches/patch_it.py
 
       - uses: actions/upload-artifact@v2
         with:
@@ -227,5 +220,4 @@ jobs:
           path: |
             build/xpython_wasm.js
             build/xpython_wasm.wasm
-            build/python_data.js
-            build/python_data.data
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,7 +212,10 @@ jobs:
             ..
 
           make -j5 
-
+          
+          popd
+          # Patch output
+          python wasm_patches/patch_it.py
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,7 +193,7 @@ jobs:
         run: |
           micromamba activate xeus-python-wasm-build
 
-          $HOME/emsdk activate ${{matrix.emsdk_ver}}
+          $HOME/emsdk/emsdk activate ${{matrix.emsdk_ver}}
           source $HOME/emsdk/emsdk_env.sh
 
           micromamba create -f environment-wasm-host.yml --platform=emscripten-32

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,16 +178,22 @@ jobs:
           environment-file: environment-wasm-build.yml
           environment-name: xeus-python-wasm-build
 
-      - name: Setup emsdk
+
+      - name: "setup emsdk"
+        shell: bash -l {0}
         run: |
           micromamba activate xeus-python-wasm-build
-          emsdk install ${{matrix.emsdk_ver}}
+          cd $HOME
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk 
+          ./emsdk install  ${{ matrix.emsdk_ver }}
+          ./emsdk activate  ${{ matrix.emsdk_ver }}
 
       - name: Build and pack xeus-python
         run: |
           micromamba activate xeus-python-wasm-build
 
-          emsdk activate ${{matrix.emsdk_ver}}
+          ./$HOME/emsdk activate ${{matrix.emsdk_ver}}
           source $CONDA_EMSDK_DIR/emsdk_env.sh
 
           micromamba create -f environment-wasm-host.yml --platform=emscripten-32

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ set(xeus-zmq_REQUIRED_VERSION 1.0.1)
 set(xeus-lite_REQUIRED_VERSION 1.0.1)
 set(pybind11_REQUIRED_VERSION 2.6.1)
 set(pybind11_json_REQUIRED_VERSION 0.2.8)
-set(pyjs_REQUIRED_VERSION 0.18.2)
+set(pyjs_REQUIRED_VERSION 1.0.0)
 
 if (NOT TARGET xtl)
     find_package(xtl ${xtl_REQUIRED_VERSION} REQUIRED)

--- a/environment-wasm-build.yml
+++ b/environment-wasm-build.yml
@@ -7,4 +7,3 @@ dependencies:
   - python=3.10
   - yarn
   - click
-  - empack >=3,<4

--- a/environment-wasm-build.yml
+++ b/environment-wasm-build.yml
@@ -7,4 +7,4 @@ dependencies:
   - python=3.10
   - yarn
   - click
-  - empack >=3,<s
+  - empack >=3,<4

--- a/environment-wasm-build.yml
+++ b/environment-wasm-build.yml
@@ -7,5 +7,4 @@ dependencies:
   - python=3.10
   - yarn
   - click
-  - emsdk >=3.1.11
-  - empack >=2.0.1
+  - empack >=3,<s

--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -13,6 +13,6 @@ dependencies:
   - xeus-lite
   - xeus 
   - xeus-python-shell>=0.5
-  - pyjs>=0.18.2
-  - requests-wasm-polyfill>=0.1.5
+  - pyjs>=1.0.0
+  - requests-wasm-polyfill>=0.3.0
   - libpython


### PR DESCRIPTION
I also removed empack from the CI which was used to pack the env in a single js/data blob. 
Since the single js/data blobs are outdated anyhow I removed that part