### PR TITLE
Wasm fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,6 +205,9 @@ jobs:
           export CMAKE_PREFIX_PATH=$PREFIX
           export CMAKE_SYSTEM_PREFIX_PATH=$PREFIX
 
+          # remove all the fake pythons binaries
+          rm -f $PREFIX/bin/python*
+
           emcmake cmake \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON \

--- a/environment-wasm-build.yml
+++ b/environment-wasm-build.yml
@@ -4,6 +4,6 @@ channels:
 dependencies:
   - cmake
   - pip
-  - python=3.10
+  - python=3.11
   - yarn
   - click


### PR DESCRIPTION
In emscripten-forge, in the python package we have some "fake" python binaries (ie `PREFIX/bin/python3`,  `PREFIX/bin/pip`  and so on) which just print the message that these binaries are not supported for that platform.
But the FindPython mechanism is confused by this, therefore we just remove these fake binaries.