### PR TITLE
Fixed m_copy_to_globals_available definition

### DIFF
--- a/src/xdebugger.cpp
+++ b/src/xdebugger.cpp
@@ -195,7 +195,7 @@ namespace xpyt
     nl::json debugger::copy_to_globals_request(const nl::json& message)
     {
         // This request cannot be processed if the version of debugpy is lower than 1.6.5.
-        if (m_copy_to_globals_available)
+        if (!m_copy_to_globals_available)
         {
             nl::json reply = {
                 {"type", "response"},
@@ -300,7 +300,7 @@ namespace xpyt
             std::replace(version.begin(), version.end(), '.', ' ');
 
             // Check if the copy_to_globals feature is available
-            m_copy_to_globals_available = less_than_version(version, "1 6 5");
+            m_copy_to_globals_available = !less_than_version(version, "1 6 5");
         }
         return status == "ok";
     }


### PR DESCRIPTION
I found this when doing some archeology for [JEP 93](https://github.com/jupyter/enhancement-proposals/pull/93). With this fix:
- the world is slightly a better place
- I can have a decent amount of sleep