### PR TITLE
update jupyter lite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This is useful when using xeus-python in [Voila](https://github.com/voila-dashbo
 
 ## xeus-python in JupyterLite!
 
-You can install xeus-python in JupyterLite, see https://github.com/jupyterlite/xeus-python-kernel for more information.
+You can install xeus-python in JupyterLite, see https://github.com/jupyterlite/xeus for more information.
 
 **Code execution and variable display**:
 


### PR DESCRIPTION
current link goes to a deprecate repo so I thought might be worth updating the link