### PR TITLE
use pyjs 2.0.0 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ set(xeus-zmq_REQUIRED_VERSION 1.2.0)
 set(xeus-lite_REQUIRED_VERSION 1.0.1)
 set(pybind11_REQUIRED_VERSION 2.6.1)
 set(pybind11_json_REQUIRED_VERSION 0.2.8)
-set(pyjs_REQUIRED_VERSION 1.3.2)
+set(pyjs_REQUIRED_VERSION 2.0.0)
 
 if (NOT TARGET xtl)
     find_package(xtl ${xtl_REQUIRED_VERSION} REQUIRED)

--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -13,6 +13,6 @@ dependencies:
   - xeus-lite
   - xeus 
   - xeus-python-shell>=0.5
-  - pyjs>=1.0.0
+  - pyjs>=2.0.0
   - requests-wasm-polyfill>=0.3.0
   - libpython

--- a/src/main_wasm.cpp
+++ b/src/main_wasm.cpp
@@ -18,7 +18,7 @@
 #include "xeus/xembind.hpp"
 #include "xeus-python/xinterpreter_wasm.hpp"
 
-PYBIND11_EMBEDDED_MODULE(pyjs, m) {
+PYBIND11_EMBEDDED_MODULE(pyjs_core, m) {
     pyjs::export_pyjs_module(m);
 }
 

--- a/src/xinterpreter_wasm.cpp
+++ b/src/xinterpreter_wasm.cpp
@@ -30,7 +30,6 @@ namespace xpyt
     wasm_interpreter::~wasm_interpreter()
     {
     }
-
     void wasm_interpreter::configure_impl()
     {
         interpreter::configure_impl();

--- a/src/xinterpreter_wasm.cpp
+++ b/src/xinterpreter_wasm.cpp
@@ -30,6 +30,7 @@ namespace xpyt
     wasm_interpreter::~wasm_interpreter()
     {
     }
+
     void wasm_interpreter::configure_impl()
     {
         interpreter::configure_impl();

--- a/wasm_patches/post.js
+++ b/wasm_patches/post.js
@@ -14,6 +14,6 @@ Module['async_init'] = async function(
     return Module['bootstrap_from_empack_packed_environment'](
     `${kernel_root_url}/empack_env_meta.json`, /* packages_json_url */
     pkg_root_url,               /* package_tarballs_root_url */
-    false                 /* verbose */
+    verbose                     /* verbose */
     );
 }

--- a/wasm_patches/post.js
+++ b/wasm_patches/post.js
@@ -14,6 +14,6 @@ Module['async_init'] = async function(
     return Module['bootstrap_from_empack_packed_environment'](
     `${kernel_root_url}/empack_env_meta.json`, /* packages_json_url */
     pkg_root_url,               /* package_tarballs_root_url */
-    verbose                 /* verbose */
+    false                 /* verbose */
     );
 }


### PR DESCRIPTION
 * the only breaking chage is, the embedded module needs to be named pyjs_core instead of pyjs