### PR TITLE
Minor fixes

### DIFF
--- a/src/xutils.cpp
+++ b/src/xutils.cpp
@@ -113,7 +113,7 @@ namespace xpyt
         void* array[10];
 
         // get void*'s for all entries on the stack
-        size_t size = backtrace(array, 10);
+        int size = backtrace(array, 10);
 
         // print out all the frames to stderr
         fprintf(stderr, "Error: signal %d:\n", sig);

--- a/test/xeus_client.cpp
+++ b/test/xeus_client.cpp
@@ -95,12 +95,12 @@ nl::json xeus_client_base::receive_on_control()
 
 void xeus_client_base::subscribe_iopub(const std::string& filter)
 {
-    m_iopub.setsockopt(ZMQ_SUBSCRIBE, filter.c_str(), filter.length());
+    m_iopub.set(zmq::sockopt::subscribe, filter);
 }
 
 void xeus_client_base::unsubscribe_iopub(const std::string& filter)
 {
-    m_iopub.setsockopt(ZMQ_UNSUBSCRIBE, filter.c_str(), filter.length());
+    m_iopub.set(zmq::sockopt::unsubscribe, filter);
 }
 
 nl::json xeus_client_base::receive_on_iopub()


### PR DESCRIPTION
Fixes these warnings:

```sh
warning: conversion from 'size_t' {aka 'long unsigned int'} to 'int' may change value [-Wconversion]
  120 |         backtrace_symbols_fd(array, size, STDERR_FILENO);
```

```sh
warning: 'void zmq::detail::socket_base::setsockopt(int, const void*, size_t)' is deprecated: from 4.7.0, use `set` taking option from zmq::sockopt [-Wdeprecated-declarations]
```