### PR TITLE
Update deprecated functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,12 @@
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 project(xeus-python)
 
 set(XEUS_PYTHON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-# Versionning
+# Versioning
 # ===========
 
 file(STRINGS "${XEUS_PYTHON_INCLUDE_DIR}/xeus-python/xeus_python_config.hpp" xpyt_version_defines
@@ -35,11 +35,6 @@ include(GNUInstallDirs)
 if (NOT DEFINED XPYTHON_KERNELSPEC_PATH)
     set(XPYTHON_KERNELSPEC_PATH "${CMAKE_INSTALL_FULL_BINDIR}/")
 endif ()
-
-# Running find_package(PythonInterp) to retrieve the Python version
-# which is not exported by Pybind11's cmake.
-# Cf. https://github.com/pybind/pybind11/issues/2268
-find_package(PythonInterp ${PythonLibsNew_FIND_VERSION} REQUIRED)
 
 if(EMSCRIPTEN)
     # the variables PYTHON_VERSION_MAJOR and PYTHON_VERSION_MINOR
@@ -112,7 +107,12 @@ set(pybind11_REQUIRED_VERSION 2.6.1)
 set(pybind11_json_REQUIRED_VERSION 0.2.8)
 set(pyjs_REQUIRED_VERSION 2.0.0)
 
+find_package(Python COMPONENTS Interpreter REQUIRED)
+
 if (NOT TARGET pybind11::headers)
+    # Defaults to ON for cmake >= 3.18
+    # https://github.com/pybind/pybind11/blob/35ff42b56e9d34d9a944266eb25f2c899dbdfed7/CMakeLists.txt#L96
+    set(PYBIND11_FINDPYTHON OFF)
     find_package(pybind11 ${pybind11_REQUIRED_VERSION} REQUIRED)
 endif ()
 if (NOT TARGET pybind11_json)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
 
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.10)
 project(xeus-python)
 
 set(XEUS_PYTHON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ project(xeus-python)
 set(XEUS_PYTHON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # Versioning
-# ===========
+# ==========
 
 file(STRINGS "${XEUS_PYTHON_INCLUDE_DIR}/xeus-python/xeus_python_config.hpp" xpyt_version_defines
      REGEX "#define XPYT_VERSION_(MAJOR|MINOR|PATCH)")
@@ -60,20 +60,20 @@ configure_file (
 
 # Compilation options
 
-OPTION(XPYT_ENABLE_PYPI_WARNING "Enable warning on PyPI wheels" OFF)
+option(XPYT_ENABLE_PYPI_WARNING "Enable warning on PyPI wheels" OFF)
 
 option(XPYT_BUILD_STATIC "Build xeus-python static library" ON)
-OPTION(XPYT_BUILD_SHARED "Split xpython build into executable and library" ON)
-OPTION(XPYT_BUILD_XPYTHON_EXECUTABLE "Build the xpython executable" ON)
-OPTION(XPYT_BUILD_XPYTHON_EXTENSION "Build the xpython extension module" OFF)
+option(XPYT_BUILD_SHARED "Split xpython build into executable and library" ON)
+option(XPYT_BUILD_XPYTHON_EXECUTABLE "Build the xpython executable" ON)
+option(XPYT_BUILD_XPYTHON_EXTENSION "Build the xpython extension module" OFF)
 
-OPTION(XPYT_USE_SHARED_XEUS "Link xpython or xpython_extension with the xeus shared library (instead of the static library)" ON)
-OPTION(XPYT_USE_SHARED_XEUS_PYTHON "Link xpython and xpython_extension with the xeus-python shared library (instead of the static library)" ON)
+option(XPYT_USE_SHARED_XEUS "Link xpython or xpython_extension with the xeus shared library (instead of the static library)" ON)
+option(XPYT_USE_SHARED_XEUS_PYTHON "Link xpython and xpython_extension with the xeus-python shared library (instead of the static library)" ON)
 
-OPTION(XPYT_EMSCRIPTEN_WASM_BUILD "Build for wasm with emscripten" OFF)
+option(XPYT_EMSCRIPTEN_WASM_BUILD "Build for wasm with emscripten" OFF)
 
 # Test options
-OPTION(XPYT_BUILD_TESTS "xeus-python test suite" OFF)
+option(XPYT_BUILD_TESTS "xeus-python test suite" OFF)
 
 function(cat IN_FILE OUT_FILE)
   file(READ ${IN_FILE} CONTENTS)

--- a/include/xeus-python/xpaths.hpp
+++ b/include/xeus-python/xpaths.hpp
@@ -12,6 +12,7 @@
 #define XPYT_PATHS_HPP
 
 #include <string>
+#include <Python.h>
 
 #include "xeus_python_config.hpp"
 
@@ -23,6 +24,10 @@ namespace xpyt
 
     XEUS_PYTHON_API std::string get_python_prefix();
     XEUS_PYTHON_API std::string get_python_path();
+
+    XEUS_PYTHON_API void set_pythonhome(PyConfig* config);
+
+    [[deprecated("Use PyConfig.home instead")]]
     XEUS_PYTHON_API void set_pythonhome();
 }
 

--- a/include/xeus-python/xpaths.hpp
+++ b/include/xeus-python/xpaths.hpp
@@ -24,8 +24,6 @@ namespace xpyt
     XEUS_PYTHON_API std::string get_python_prefix();
     XEUS_PYTHON_API std::string get_python_path();
 
-    XEUS_PYTHON_API void set_pythonhome(PyConfig* config);
-
     [[deprecated("Use PyConfig.home instead")]]
     XEUS_PYTHON_API void set_pythonhome();
 }

--- a/include/xeus-python/xpaths.hpp
+++ b/include/xeus-python/xpaths.hpp
@@ -12,7 +12,6 @@
 #define XPYT_PATHS_HPP
 
 #include <string>
-#include <Python.h>
 
 #include "xeus_python_config.hpp"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,12 +81,6 @@ int main(int argc, char* argv[])
     static const std::wstring wexecutable(executable.cbegin(), executable.cend());
     config.program_name = const_cast<wchar_t*>(wexecutable.c_str());
 
-    // On windows, sys.executable is not properly set with Py_SetProgramName
-    // Cf. https://github.com/python/cpython/issues/78906
-    // A private undocumented API was added as a workaround in Python 3.7.2.
-    // _Py_SetProgramFullPath(const_cast<wchar_t*>(wexecutable.c_str()));
-    // Py_SetProgramName(const_cast<wchar_t*>(wexecutable.c_str()));
-
     // Setting Python Home
     static const std::string pythonhome{ xpyt::get_python_prefix() };
     static const std::wstring wstr(pythonhome.cbegin(), pythonhome.cend());;
@@ -99,7 +93,6 @@ int main(int argc, char* argv[])
         std::cerr << "Error:" << status.err_msg << std::endl;
     }
 
-    // TODO: may need to use safe_path
     // Setting argv
     wchar_t** argw = new wchar_t*[size_t(argc)];
     for(auto i = 0; i < argc; ++i)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,8 +91,7 @@ int main(int argc, char* argv[])
     static const std::string pythonhome{ xpyt::get_python_prefix() };
     static const std::wstring wstr(pythonhome.cbegin(), pythonhome.cend());;
     config.home = const_cast<wchar_t*>(wstr.c_str());
-    // Py_GetPythonHome will return NULL if called before Py_Initialize()
-    // xpyt::print_pythonhome();
+    xpyt::print_pythonhome();
 
     // Implicitly pre-initialize Python
     status = PyConfig_SetBytesArgv(&config, argc, argv);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,13 +91,13 @@ int main(int argc, char* argv[])
     static const std::string pythonhome{ xpyt::get_python_prefix() };
     static const std::wstring wstr(pythonhome.cbegin(), pythonhome.cend());;
     config.home = const_cast<wchar_t*>(wstr.c_str());
-    // xpyt::print_pythonhome(); FIXME:
+    // Py_GetPythonHome will return NULL if called before Py_Initialize()
+    // xpyt::print_pythonhome();
 
     // Implicitly pre-initialize Python
     status = PyConfig_SetBytesArgv(&config, argc, argv);
     if (PyStatus_Exception(status)) {
-        // TODO: handle error;
-        std::cout << "Error" << std::endl;
+        std::cerr << "Error:" << status.err_msg << std::endl;
     }
 
     // TODO: may need to use safe_path

--- a/src/xpaths.cpp
+++ b/src/xpaths.cpp
@@ -11,7 +11,6 @@
 #include <iostream>
 #include <string>
 #include <cstring>
-#include <Python.h>
 
 #include "pybind11/pybind11.h"
 

--- a/src/xpaths.cpp
+++ b/src/xpaths.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <string>
 #include <cstring>
+#include <Python.h>
 
 #include "pybind11/pybind11.h"
 
@@ -68,10 +69,12 @@ namespace xpyt
 #endif
     }
 
+    [[deprecated]]
     void set_pythonhome()
     {
-        static const std::string pythonhome = get_python_prefix();
-        static const std::wstring wstr(pythonhome.cbegin(), pythonhome.cend());;
-        Py_SetPythonHome(const_cast<wchar_t*>(wstr.c_str()));
+        // static const std::string pythonhome = get_python_prefix();
+        // static const std::wstring wstr(pythonhome.cbegin(), pythonhome.cend());;
+        // Py_SetPythonHome(const_cast<wchar_t*>(wstr.c_str()));
     }
+
 }

--- a/src/xutils.cpp
+++ b/src/xutils.cpp
@@ -139,12 +139,19 @@ namespace xpyt
     void print_pythonhome()
     {
         std::setlocale(LC_ALL, "en_US.utf8");
+        // Py_GetPythonHome will return NULL if called before Py_Initialize()
         wchar_t* ph = Py_GetPythonHome();
 
-        char mbstr[1024];
-        std::wcstombs(mbstr, ph, 1024);
-
-        std::clog << "PYTHONHOME set to " << mbstr << std::endl;
+        if (ph)
+        {
+            char mbstr[1024];
+            std::wcstombs(mbstr, ph, 1024);
+            std::clog << "PYTHONHOME set to " << mbstr << std::endl;
+        }
+        else
+        {
+            std::clog << "PYTHONHOME not set or not initialized." << std::endl;
+        }
     }
 
     // Compares 2 versions and return true if version1 < version2.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,7 @@
 # Unit tests
 # ==========
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xeus-python-test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,7 @@
 # Unit tests
 # ==========
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xeus-python-test)


### PR DESCRIPTION

- `find_package(PythonInterp)` is deprecated since cmake v3.12 (See [FindPythonInterp](https://cmake.org/cmake/help/latest/module/FindPythonInterp.html)).

- The following have been deprecated since Python 3.11 and are replaced with a `PyConfig` structure introduced in Python 3.8
  - `Py_SetProgramName`
  - `Py_SetPythonHome`
  - `PySys_SetArgvEx`
