### PR TITLE
Refactoring some utilities

### DIFF
--- a/include/xeus-python/xutils.hpp
+++ b/include/xeus-python/xutils.hpp
@@ -34,9 +34,6 @@ namespace xpyt
     XEUS_PYTHON_API bool holding_gil();
 
     XEUS_PYTHON_API
-    std::string extract_parameter(std::string param, int argc, char* argv[]);
-
-    XEUS_PYTHON_API
     bool extract_option(std::string short_opt, std::string long_opt, int argc, char* argv[]);
 
 #define XPYT_HOLDING_GIL(func)           \
@@ -61,9 +58,6 @@ namespace xpyt
 
     XEUS_PYTHON_API
     void sigkill_handler(int sig);
-
-    XEUS_PYTHON_API
-    bool should_print_version(int argc, char* argv[]);
 
     XEUS_PYTHON_API
     void print_pythonhome();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,7 @@
 #include "xeus/xkernel.hpp"
 #include "xeus/xkernel_configuration.hpp"
 #include "xeus/xinterpreter.hpp"
+#include "xeus/xhelper.hpp"
 
 #include "xeus-zmq/xserver_zmq_split.hpp"
 #include "xeus-zmq/xzmq_context.hpp"
@@ -43,7 +44,7 @@ namespace py = pybind11;
 
 int main(int argc, char* argv[])
 {
-    if (xpyt::should_print_version(argc, argv))
+    if (xeus::should_print_version(argc, argv))
     {
         std::clog << "xpython " << XPYT_VERSION << std::endl;
         return 0;
@@ -133,7 +134,7 @@ int main(int argc, char* argv[])
     using history_manager_ptr = std::unique_ptr<xeus::xhistory_manager>;
     history_manager_ptr hist = xeus::make_in_memory_history_manager();
 
-    std::string connection_filename = xpyt::extract_parameter("-f", argc, argv);
+    std::string connection_filename = xeus::extract_filename(argc, argv);
 
 #ifdef XEUS_PYTHON_PYPI_WARNING
     std::clog <<

--- a/src/xpython_extension.cpp
+++ b/src/xpython_extension.cpp
@@ -23,6 +23,7 @@
 
 #include "xeus/xkernel.hpp"
 #include "xeus/xkernel_configuration.hpp"
+#include "xeus/xhelper.hpp"
 
 #include "xeus-zmq/xserver_zmq_split.hpp"
 #include "xeus-zmq/xzmq_context.hpp"
@@ -48,7 +49,7 @@ void launch(const py::list args_list)
         argv[i] = (char*)PyUnicode_AsUTF8(args_list[i].ptr());
     }
 
-    if (xpyt::should_print_version(argc, argv.data()))
+    if (xeus::should_print_version(argc, argv.data()))
     {
         std::clog << "xpython " << XPYT_VERSION << std::endl;
         return;
@@ -65,7 +66,7 @@ void launch(const py::list args_list)
     signal(SIGINT, xpyt::sigkill_handler);
 
     bool raw_mode = xpyt::extract_option("-r", "--raw", argc, argv.data());
-    std::string connection_filename = xpyt::extract_parameter("-f", argc, argv.data());
+    std::string connection_filename = xeus::extract_filename(argc, argv.data());
 
     std::unique_ptr<xeus::xcontext> context = xeus::make_zmq_context();
 

--- a/src/xutils.cpp
+++ b/src/xutils.cpp
@@ -66,25 +66,6 @@ namespace xpyt
         return py::eval(code, scope);
     }
 
-    std::string extract_parameter(std::string param, int argc, char* argv[])
-    {
-        std::string res = "";
-        for (int i = 0; i < argc; ++i)
-        {
-            if ((std::string(argv[i]) == param) && (i + 1 < argc))
-            {
-                res = argv[i + 1];
-                for (int j = i; j < argc - 2; ++j)
-                {
-                    argv[j] = argv[j + 2];
-                }
-                argc -= 2;
-                break;
-            }
-        }
-        return res;
-    }
-
     bool extract_option(std::string short_opt, std::string long_opt, int argc, char* argv[])
     {
         bool res = false;
@@ -122,18 +103,6 @@ namespace xpyt
     void sigkill_handler(int /*sig*/)
     {
         exit(0);
-    }
-
-    bool should_print_version(int argc, char* argv[])
-    {
-        for (int i = 0; i < argc; ++i)
-        {
-            if (std::string(argv[i]) == "--version")
-            {
-                return true;
-            }
-        }
-        return false;
     }
 
     void print_pythonhome()


### PR DESCRIPTION
This pr drops `should_print_version` (can be used out of xeus) and `extract_parameter` (can be replaced by `extract_filename` from xeus as `extract_parameter` is not used for anything but extracting the filename currently)