### PR TITLE
Passing the link of empack_env_meta.json file

### DIFF
--- a/wasm_patches/post.js
+++ b/wasm_patches/post.js
@@ -22,11 +22,10 @@ Module['async_init'] = async function(
      packages_json_url = empack_env_meta_link;
     }
      
-
     Module['bootstrap_from_empack_packed_environment']
     return Module['bootstrap_from_empack_packed_environment'](
     packages_json_url,
     pkg_root_url,               /* package_tarballs_root_url */
-    verbose,                    /* verbose */          
+    verbose,                    /* verbose */
     );
 }

--- a/wasm_patches/post.js
+++ b/wasm_patches/post.js
@@ -9,11 +9,27 @@ Module.ERRNO_CODES = ERRNO_CODES;
 Module['async_init'] = async function(
     kernel_root_url, 
     pkg_root_url,
-    verbose) {
+    verbose,
+    url_empack_env_meta = '') {
+
+    /* It should work with any kernel so we have to keep logic for this too
+       by default it will work with local empack_env_meta.json
+    */
+    let packages_json_url = `${kernel_root_url}/empack_env_meta.json`;
+    let isEmpackEnvMetaHosted = false;
+
+    // if we host empack_env_meta somewhere else then we have to proceed it
+    if (url_empack_env_meta) {
+     packages_json_url = url_empack_env_meta;
+     isEmpackEnvMetaHosted = true;
+    }
+     
+
     Module['bootstrap_from_empack_packed_environment']
     return Module['bootstrap_from_empack_packed_environment'](
-    `${kernel_root_url}/empack_env_meta.json`, /* packages_json_url */
+    packages_json_url,
     pkg_root_url,               /* package_tarballs_root_url */
-    verbose                     /* verbose */
+    verbose,                    /* verbose */
+    isEmpackEnvMetaHosted      /* if we host empack_env_meta somewhere else */             
     );
 }

--- a/wasm_patches/post.js
+++ b/wasm_patches/post.js
@@ -10,7 +10,7 @@ Module['async_init'] = async function(
     kernel_root_url, 
     pkg_root_url,
     verbose,
-    url_empack_env_meta = '') {
+    empack_env_meta_link = '') {
 
     /* It should work with any kernel so we have to keep logic for this too
        by default it will work with local empack_env_meta.json
@@ -19,8 +19,8 @@ Module['async_init'] = async function(
     let isEmpackEnvMetaHosted = false;
 
     // if we host empack_env_meta somewhere else then we have to proceed it
-    if (url_empack_env_meta) {
-     packages_json_url = url_empack_env_meta;
+    if (empack_env_meta_link) {
+     packages_json_url = empack_env_meta_link;
      isEmpackEnvMetaHosted = true;
     }
      

--- a/wasm_patches/post.js
+++ b/wasm_patches/post.js
@@ -16,12 +16,10 @@ Module['async_init'] = async function(
        by default it will work with local empack_env_meta.json
     */
     let packages_json_url = `${kernel_root_url}/empack_env_meta.json`;
-    let isEmpackEnvMetaHosted = false;
 
     // if we host empack_env_meta somewhere else then we have to proceed it
     if (empack_env_meta_link) {
      packages_json_url = empack_env_meta_link;
-     isEmpackEnvMetaHosted = true;
     }
      
 
@@ -29,7 +27,6 @@ Module['async_init'] = async function(
     return Module['bootstrap_from_empack_packed_environment'](
     packages_json_url,
     pkg_root_url,               /* package_tarballs_root_url */
-    verbose,                    /* verbose */
-    isEmpackEnvMetaHosted      /* if we host empack_env_meta somewhere else */             
+    verbose,                    /* verbose */          
     );
 }


### PR DESCRIPTION
This PR is the part of the solution of https://github.com/QuantStack/qs.ai/issues/28
It replaces the hardcoded meantion  of "empack_env_meta.json" file by a variable where this file is located. 

It should be used with https://github.com/jupyterlite/xeus/pull/120 and https://github.com/emscripten-forge/pyjs/pull/69 together